### PR TITLE
Added another toString method to AbstractIpRange

### DIFF
--- a/commons-ip-math/src/main/java/com/github/jgonian/ipmath/AbstractIpRange.java
+++ b/commons-ip-math/src/main/java/com/github/jgonian/ipmath/AbstractIpRange.java
@@ -24,10 +24,12 @@
 
 package com.github.jgonian.ipmath;
 
-import static java.math.BigInteger.*;
 import java.math.BigInteger;
 import java.util.LinkedList;
 import java.util.List;
+
+import static java.math.BigInteger.ONE;
+import static java.math.BigInteger.ZERO;
 
 public abstract class AbstractIpRange<C extends AbstractIp<C, R>, R extends AbstractIpRange<C, R>>
         extends AbstractRange<C, R>
@@ -35,6 +37,7 @@ public abstract class AbstractIpRange<C extends AbstractIp<C, R>, R extends Abst
 
     protected static final String SLASH = "/";
     protected static final String DASH = "-";
+    protected static final String DASH_WITH_SPACES = " - ";
     private static final BigInteger TWO = BigInteger.valueOf(2);
 
     protected AbstractIpRange(C start, C end) {
@@ -54,6 +57,10 @@ public abstract class AbstractIpRange<C extends AbstractIp<C, R>, R extends Abst
 
     public String toStringInRangeNotation() {
         return start() + DASH + end();
+    }
+
+    public String toStringInRangeWithSpacesNotation() {
+        return start() + DASH_WITH_SPACES + end();
     }
 
     public String toStringInCidrNotation() {

--- a/commons-ip-math/src/test/java/com/github/jgonian/ipmath/Ipv4RangeTest.java
+++ b/commons-ip-math/src/test/java/com/github/jgonian/ipmath/Ipv4RangeTest.java
@@ -23,17 +23,17 @@
  */
 package com.github.jgonian.ipmath;
 
-import static junit.framework.Assert.*;
-import static com.github.jgonian.ipmath.Ipv4.FIRST_IPV4_ADDRESS;
-import static com.github.jgonian.ipmath.Ipv4.LAST_IPV4_ADDRESS;
-import static com.github.jgonian.ipmath.Ipv4.MAXIMUM_VALUE;
-import static org.junit.Assert.assertEquals;
+import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.Test;
+import static com.github.jgonian.ipmath.Ipv4.FIRST_IPV4_ADDRESS;
+import static com.github.jgonian.ipmath.Ipv4.LAST_IPV4_ADDRESS;
+import static com.github.jgonian.ipmath.Ipv4.MAXIMUM_VALUE;
+import static junit.framework.Assert.assertFalse;
+import static org.junit.Assert.assertEquals;
 
 public class Ipv4RangeTest extends AbstractRangeTest<Ipv4, Ipv4Range> {
 
@@ -162,7 +162,12 @@ public class Ipv4RangeTest extends AbstractRangeTest<Ipv4, Ipv4Range> {
     public void testToStringInRangeNotation() {
         assertEquals("0.0.0.0-255.255.255.255", new Ipv4Range(FIRST_IPV4_ADDRESS, LAST_IPV4_ADDRESS).toStringInRangeNotation());
     }
-    
+
+    @Test
+    public void testToStringInRangeWithSpacesNotation() {
+        assertEquals("0.0.0.0 - 255.255.255.255", new Ipv4Range(FIRST_IPV4_ADDRESS, LAST_IPV4_ADDRESS).toStringInRangeWithSpacesNotation());
+    }
+
     @Test
     public void testToStringSpecialFoundInvalidCase() {
         assertFalse("94.126.33.0/23".equals(Ipv4Range.from(1585324288L).to(1585324799L).toString()));

--- a/commons-ip-math/src/test/java/com/github/jgonian/ipmath/Ipv6RangeTest.java
+++ b/commons-ip-math/src/test/java/com/github/jgonian/ipmath/Ipv6RangeTest.java
@@ -23,15 +23,17 @@
  */
 package com.github.jgonian.ipmath;
 
-import static java.math.BigInteger.*;
-import static com.github.jgonian.ipmath.Ipv6.*;
-import static org.junit.Assert.*;
+import org.junit.Test;
+
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.Test;
+import static com.github.jgonian.ipmath.Ipv6.FIRST_IPV6_ADDRESS;
+import static com.github.jgonian.ipmath.Ipv6.LAST_IPV6_ADDRESS;
+import static java.math.BigInteger.ONE;
+import static org.junit.Assert.assertEquals;
 
 public class Ipv6RangeTest extends AbstractRangeTest<Ipv6, Ipv6Range> {
 
@@ -155,6 +157,11 @@ public class Ipv6RangeTest extends AbstractRangeTest<Ipv6, Ipv6Range> {
     @Test
     public void testToStringInRangeNotation() {
         assertEquals("::-ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff", new Ipv6Range(FIRST_IPV6_ADDRESS, LAST_IPV6_ADDRESS).toStringInRangeNotation());
+    }
+
+    @Test
+    public void testToStringInRangeWithSpacesNotation() {
+        assertEquals(":: - ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff", new Ipv6Range(FIRST_IPV6_ADDRESS, LAST_IPV6_ADDRESS).toStringInRangeWithSpacesNotation());
     }
 
     @Test


### PR DESCRIPTION
The existing implementation of the AbstractIpRange provides the toStringInRangeNotation method to print a range as:
<IP-start>-<IP-end> 
I added another toString method which adds a space before and after the dash. 

Reason:
All the Regional Internet Registries that provide Whois related services make use of the following notation to display inetnum objects in RPSL format: 
<IP-start> - <IP-end>
It would be handy if the library provided this extra toString method for Ipv4Range so that we do not need wrappers in the code that uses the library to achieve the same functionality.

Please feel free, if you think appropriate, to rename the method, or add it to the Ipv4Range class only.
