### PR TITLE
renamed toStringInRangeWithSpacesNotation

### DIFF
--- a/commons-ip-math/src/main/java/com/github/jgonian/ipmath/AbstractIpRange.java
+++ b/commons-ip-math/src/main/java/com/github/jgonian/ipmath/AbstractIpRange.java
@@ -59,7 +59,7 @@ public abstract class AbstractIpRange<C extends AbstractIp<C, R>, R extends Abst
         return start() + DASH + end();
     }
 
-    public String toStringInRangeWithSpacesNotation() {
+    public String toStringInRangeNotationWithSpaces() {
         return start() + DASH_WITH_SPACES + end();
     }
 

--- a/commons-ip-math/src/test/java/com/github/jgonian/ipmath/Ipv4RangeTest.java
+++ b/commons-ip-math/src/test/java/com/github/jgonian/ipmath/Ipv4RangeTest.java
@@ -164,8 +164,8 @@ public class Ipv4RangeTest extends AbstractRangeTest<Ipv4, Ipv4Range> {
     }
 
     @Test
-    public void testToStringInRangeWithSpacesNotation() {
-        assertEquals("0.0.0.0 - 255.255.255.255", new Ipv4Range(FIRST_IPV4_ADDRESS, LAST_IPV4_ADDRESS).toStringInRangeWithSpacesNotation());
+    public void testToStringInRangeNotationWithSpaces() {
+        assertEquals("0.0.0.0 - 255.255.255.255", new Ipv4Range(FIRST_IPV4_ADDRESS, LAST_IPV4_ADDRESS).toStringInRangeNotationWithSpaces());
     }
 
     @Test

--- a/commons-ip-math/src/test/java/com/github/jgonian/ipmath/Ipv6RangeTest.java
+++ b/commons-ip-math/src/test/java/com/github/jgonian/ipmath/Ipv6RangeTest.java
@@ -160,8 +160,8 @@ public class Ipv6RangeTest extends AbstractRangeTest<Ipv6, Ipv6Range> {
     }
 
     @Test
-    public void testToStringInRangeWithSpacesNotation() {
-        assertEquals(":: - ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff", new Ipv6Range(FIRST_IPV6_ADDRESS, LAST_IPV6_ADDRESS).toStringInRangeWithSpacesNotation());
+    public void testToStringInRangeNotationWithSpaces() {
+        assertEquals(":: - ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff", new Ipv6Range(FIRST_IPV6_ADDRESS, LAST_IPV6_ADDRESS).toStringInRangeNotationWithSpaces());
     }
 
     @Test


### PR DESCRIPTION
renamed toStringInRangeWithSpacesNotation in AbstractIpRange to toStringInRangeNotationWithSpaces as suggested by the lib author