### PR TITLE
Handle IPv4-embedded IPv6 addresses with leading zeros

### DIFF
--- a/commons-ip-math/src/main/java/com/github/jgonian/ipmath/Ipv6.java
+++ b/commons-ip-math/src/main/java/com/github/jgonian/ipmath/Ipv6.java
@@ -24,6 +24,7 @@
 package com.github.jgonian.ipmath;
 
 import java.math.BigInteger;
+import java.util.regex.Pattern;
 
 import static java.math.BigInteger.ONE;
 
@@ -49,6 +50,8 @@ public final class Ipv6 extends AbstractIp<Ipv6, Ipv6Range> {
     private static final int TOTAL_OCTETS = 8;
     private static final int COLON_COUNT_IPV6 = 7;
     private static final BigInteger MINUS_ONE = BigInteger.valueOf(-1);
+
+    private static final Pattern LEADING_ZERO_IN_IPV4 = Pattern.compile("(^|\\.)0[0-9]");
 
     private final BigInteger value;
 
@@ -228,9 +231,12 @@ public final class Ipv6 extends AbstractIp<Ipv6, Ipv6Range> {
         final int indexOfLastColon = ipv6String.lastIndexOf(COLON);
         final String ipv6Section = ipv6String.substring(0, indexOfLastColon);
         final String ipv4Section = ipv6String.substring(indexOfLastColon + 1);
+        Validate.isTrue(!LEADING_ZERO_IN_IPV4.matcher(ipv4Section).find(),
+                "The IPv4 part in an IPv6 address cannot have leading zeros, as this may be mistaken for octal numbers.");
         final Ipv4 ipv4 = Ipv4.parse(ipv4Section);
-        final Ipv6 ipv6FromIpv4 = new Ipv6(BigInteger.valueOf(ipv4.value()));
-        return ipv6Section + ipv6FromIpv4.toString().substring(1);
+        final String ipv4FirstPart =  Long.toHexString( ipv4.value() >>> BITS_PER_PART);
+        final String ipv4SecondPart =  Long.toHexString(ipv4.value() & MAX_PART_VALUE);
+        return ipv6Section + COLON +  ipv4FirstPart + COLON + ipv4SecondPart;
     }
 
     @Override

--- a/commons-ip-math/src/test/java/com/github/jgonian/ipmath/Ipv6ParseInvalidTest.java
+++ b/commons-ip-math/src/test/java/com/github/jgonian/ipmath/Ipv6ParseInvalidTest.java
@@ -136,8 +136,7 @@ public class Ipv6ParseInvalidTest {
                 // Testing IPv4 addresses represented as dotted-quads
                 // Leading zero's in IPv4 addresses not allowed: some systems treat the leading "0" in ".086" as the start of an octal number
                 // Update: The BNF in RFC-3986 explicitly defines the dec-octet (for IPv4 addresses) not to have a leading zero
-                // FIXME
-                //"fe80:0000:0000:0000:0204:61ff:254.157.241.086",
+                "fe80:0000:0000:0000:0204:61ff:254.157.241.086",
                 "XXXX:XXXX:XXXX:XXXX:XXXX:XXXX:1.2.3.4",
                 "1111:2222:3333:4444:5555:6666:00.00.00.00",
                 "1111:2222:3333:4444:5555:6666:000.000.000.000",

--- a/commons-ip-math/src/test/java/com/github/jgonian/ipmath/Ipv6Test.java
+++ b/commons-ip-math/src/test/java/com/github/jgonian/ipmath/Ipv6Test.java
@@ -25,7 +25,6 @@ package com.github.jgonian.ipmath;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.math.BigInteger;
@@ -411,7 +410,6 @@ public class Ipv6Test {
         }
     }
 
-    @Ignore("TODO(yg): this ipv4 is valid but ambiguous due to leading zeros and octal notation - update parsing to make this test succeed")
     @Test
     public void shouldFailIfIpv4PartContainsLeadingZeros() {
         try {
@@ -431,6 +429,15 @@ public class Ipv6Test {
         assertEquals(Ipv6.parse("::0.0.255.255"), Ipv6.parse("::ffff"));
         assertEquals(Ipv6.parse("::0.1.255.255"), Ipv6.parse("::1:ffff"));
         assertEquals(Ipv6.parse("::255.255.255.255"), Ipv6.parse("::ffff:ffff"));
+
+        assertEquals(Ipv6.parse("::ffff:0.0.0.0"), Ipv6.parse("::ffff:0:0"));
+        assertEquals(Ipv6.parse("::ffff:0.0.0.1"), Ipv6.parse("::ffff:0:1"));
+        assertEquals(Ipv6.parse("::ffff:0.0.1.0"), Ipv6.parse("::ffff:0:100"));
+        assertEquals(Ipv6.parse("::ffff:0.1.0.0"), Ipv6.parse("::ffff:1:0"));
+        assertEquals(Ipv6.parse("::ffff:1.0.0.0"), Ipv6.parse("::ffff:100:0"));
+        assertEquals(Ipv6.parse("::ffff:0.0.255.255"), Ipv6.parse("::ffff:0:ffff"));
+        assertEquals(Ipv6.parse("::ffff:0.1.255.255"), Ipv6.parse("::ffff:1:ffff"));
+        assertEquals(Ipv6.parse("::ffff:255.255.255.255"), Ipv6.parse("::ffff:ffff:ffff"));
     }
 
     // IPv6 Ranges


### PR DESCRIPTION
If the IPv6 address to be parsed ends with an IPv4 address in dot notation, the IPv4 portion will be represented by two parts in hexadecimal notation. If the first part is 0 (because the  IPv4 address in dot notation starts with "0.0."), it would fail to (correctly) parse the overall address, when the IPv6 prefix is not all zeros.
One practical use case of the dot notation is IPv4-embedded IPv6 addresses.  Without this change "::ffff:0.0.0.0" failed to parse, because it was rewritten to "::ffff:" and e.g. "::ffff:0.0.0.1" was rewritten to "::ffff:1", when it should have been "::ffff:0:1".