### PR TITLE
Some modernisation. 

### DIFF
--- a/commons-ip-math-gwt/pom.xml
+++ b/commons-ip-math-gwt/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.jgonian</groupId>
         <artifactId>commons-ip-math-parent</artifactId>
-        <version>1.33-SNAPSHOT</version>
+        <version>2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>commons-ip-math-gwt</artifactId>

--- a/commons-ip-math/pom.xml
+++ b/commons-ip-math/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.github.jgonian</groupId>
         <artifactId>commons-ip-math-parent</artifactId>
-        <version>1.33-SNAPSHOT</version>
+        <version>2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>commons-ip-math</artifactId>
@@ -16,13 +16,13 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>nl.jqno.equalsverifier</groupId>
             <artifactId>equalsverifier</artifactId>
-            <version>1.7.5</version>
+            <version>3.14.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -34,6 +34,50 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                        </manifest>
+						<manifestEntries>
+							<Multi-Release>true</Multi-Release>
+						</manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>compile</id>
+						<goals>
+							<goal>compile</goal>
+						</goals>
+						<configuration>
+							<release>8</release>
+						</configuration>
+					</execution>
+					<execution>
+						<id>compile9</id>
+						<phase>compile</phase>
+						<goals>
+							<goal>compile</goal>
+						</goals>
+						<configuration>
+							<release>9</release>
+							<compileSourceRoots>
+								<compileSourceRoot>${project.basedir}/src/main/java</compileSourceRoot>
+								<compileSourceRoot>${project.basedir}/src/main/java9</compileSourceRoot>
+							</compileSourceRoots>
+							<multiReleaseOutput>true</multiReleaseOutput>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
         </plugins>
     </build>
 </project>

--- a/commons-ip-math/src/main/java/com/github/jgonian/ipmath/AbstractIp.java
+++ b/commons-ip-math/src/main/java/com/github/jgonian/ipmath/AbstractIp.java
@@ -23,6 +23,7 @@
  */
 package com.github.jgonian.ipmath;
 
+@SuppressWarnings("serial")
 public abstract class AbstractIp<T extends AbstractIp<T, R>, R extends AbstractIpRange<T, R>>
         implements SingleInternetResource<T, R> {
 

--- a/commons-ip-math/src/main/java/com/github/jgonian/ipmath/AbstractIpRange.java
+++ b/commons-ip-math/src/main/java/com/github/jgonian/ipmath/AbstractIpRange.java
@@ -30,6 +30,7 @@ import java.util.List;
 import static java.math.BigInteger.ONE;
 import static java.math.BigInteger.ZERO;
 
+@SuppressWarnings("serial")
 public abstract class AbstractIpRange<C extends AbstractIp<C, R>, R extends AbstractIpRange<C, R>>
         extends AbstractRange<C, R>
         implements InternetResourceRange<C, R> {

--- a/commons-ip-math/src/main/java/com/github/jgonian/ipmath/AbstractRange.java
+++ b/commons-ip-math/src/main/java/com/github/jgonian/ipmath/AbstractRange.java
@@ -28,6 +28,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
+@SuppressWarnings("serial")
 public abstract class AbstractRange<C extends Rangeable<C, R>, R extends Range<C, R>> implements Range<C, R> {
 
     private final C start;
@@ -188,7 +189,7 @@ public abstract class AbstractRange<C extends Rangeable<C, R>, R extends Range<C
         if (!(o instanceof AbstractRange)) {
             return false;
         }
-        AbstractRange that = (AbstractRange) o;
+        AbstractRange<?,?> that = (AbstractRange<?,?>) o;
         if (!start.equals(that.start)) {
             return false;
         }

--- a/commons-ip-math/src/main/java/com/github/jgonian/ipmath/AsnRange.java
+++ b/commons-ip-math/src/main/java/com/github/jgonian/ipmath/AsnRange.java
@@ -23,6 +23,7 @@
  */
 package com.github.jgonian.ipmath;
 
+@SuppressWarnings("serial")
 public final class AsnRange extends AbstractRange<Asn, AsnRange> implements InternetResourceRange<Asn, AsnRange> {
 
     protected AsnRange(Asn start, Asn end) {

--- a/commons-ip-math/src/main/java/com/github/jgonian/ipmath/Ipv6.java
+++ b/commons-ip-math/src/main/java/com/github/jgonian/ipmath/Ipv6.java
@@ -24,7 +24,6 @@
 package com.github.jgonian.ipmath;
 
 import java.math.BigInteger;
-import java.util.regex.Pattern;
 
 import static java.math.BigInteger.ONE;
 

--- a/commons-ip-math/src/main/java/com/github/jgonian/ipmath/SizeComparator.java
+++ b/commons-ip-math/src/main/java/com/github/jgonian/ipmath/SizeComparator.java
@@ -47,7 +47,7 @@ public final class SizeComparator<R extends Range<?, R>> implements Comparator<R
     private SizeComparator() {
     }
 
-    @SuppressWarnings({"unchecked"})
+    @SuppressWarnings({"unchecked", "rawtypes"})
     @Override
     public int compare(R left, R right) {
         return ((Comparable)left.size()).compareTo(right.size());

--- a/commons-ip-math/src/main/java/com/github/jgonian/ipmath/SortedRangeSet.java
+++ b/commons-ip-math/src/main/java/com/github/jgonian/ipmath/SortedRangeSet.java
@@ -142,7 +142,7 @@ public class SortedRangeSet<C extends Rangeable<C, R>, R extends Range<C, R>> im
         if (!(o instanceof SortedRangeSet)) {
             return false;
         }
-        SortedRangeSet that = (SortedRangeSet) o;
+        SortedRangeSet<?, ?> that = (SortedRangeSet<?, ?>) o;
         return set.equals(that.set);
     }
 

--- a/commons-ip-math/src/main/java9/module-info.java
+++ b/commons-ip-math/src/main/java9/module-info.java
@@ -1,0 +1,3 @@
+module com.github.jgonian.ipmath {
+	exports com.github.jgonian.ipmath;
+}

--- a/commons-ip-math/src/test/java/com/github/jgonian/ipmath/AbstractRangeTest.java
+++ b/commons-ip-math/src/test/java/com/github/jgonian/ipmath/AbstractRangeTest.java
@@ -23,9 +23,9 @@
  */
 package com.github.jgonian.ipmath;
 
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -830,7 +830,8 @@ public abstract class AbstractRangeTest<C extends Rangeable<C, R>, R extends Abs
         assertEquals(result, range.exclude(other));
     }
 
-    @Test
+    @SuppressWarnings("serial")
+	@Test
     public void shouldRemoveIfOtherIsContained() {
         // range      |---------|    [10, 20]
         // other         |--|        [13, 15]

--- a/commons-ip-math/src/test/java/com/github/jgonian/ipmath/AsnRangeTest.java
+++ b/commons-ip-math/src/test/java/com/github/jgonian/ipmath/AsnRangeTest.java
@@ -23,7 +23,9 @@
  */
 package com.github.jgonian.ipmath;
 
-import static junit.framework.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 import static com.github.jgonian.ipmath.Asn.*;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -117,9 +119,9 @@ public class AsnRangeTest extends AbstractRangeTest<Asn, AsnRange> {
 
     @Test
     public void testSize() {
-        assertEquals(new Long(1), as1.asRange().size());
-        assertEquals(new Long(ASN_16_BIT_MAX_VALUE + 1), AsnRange.from(FIRST_ASN).to(Asn.LAST_16_BIT_ASN).size());
-        assertEquals(new Long(ASN_32_BIT_MAX_VALUE + 1), AsnRange.from(FIRST_ASN).to(Asn.LAST_32_BIT_ASN).size());
+        assertEquals(Long.valueOf(1), as1.asRange().size());
+        assertEquals(Long.valueOf(ASN_16_BIT_MAX_VALUE + 1), AsnRange.from(FIRST_ASN).to(Asn.LAST_16_BIT_ASN).size());
+        assertEquals(Long.valueOf(ASN_32_BIT_MAX_VALUE + 1), AsnRange.from(FIRST_ASN).to(Asn.LAST_32_BIT_ASN).size());
     }
 
     @Override

--- a/commons-ip-math/src/test/java/com/github/jgonian/ipmath/Ipv4ParseInvalidTest.java
+++ b/commons-ip-math/src/test/java/com/github/jgonian/ipmath/Ipv4ParseInvalidTest.java
@@ -23,31 +23,28 @@
  */
 package com.github.jgonian.ipmath;
 
-import org.junit.Rule;
+import static org.junit.Assert.assertThrows;
+
+import java.util.Arrays;
+import java.util.List;
+
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
-import java.util.Arrays;
-import java.util.List;
-
 @RunWith(Parameterized.class)
 public class Ipv4ParseInvalidTest {
-
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
 
     @Parameter(0)
     public String input;
 
     @Test
     public void test() {
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("Invalid IPv4 address: '" + input + "'");
-        Ipv4.parse(input);
+        assertThrows("Invalid IPv4 address: '" + input + "'", IllegalArgumentException.class, () -> {
+            Ipv4.parse(input);
+        });
     }
 
     @Parameters(name = "{index}: parse({0})")

--- a/commons-ip-math/src/test/java/com/github/jgonian/ipmath/Ipv4RangeTest.java
+++ b/commons-ip-math/src/test/java/com/github/jgonian/ipmath/Ipv4RangeTest.java
@@ -32,7 +32,7 @@ import java.util.List;
 import static com.github.jgonian.ipmath.Ipv4.FIRST_IPV4_ADDRESS;
 import static com.github.jgonian.ipmath.Ipv4.LAST_IPV4_ADDRESS;
 import static com.github.jgonian.ipmath.Ipv4.MAXIMUM_VALUE;
-import static junit.framework.Assert.assertFalse;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertEquals;
 
 public class Ipv4RangeTest extends AbstractRangeTest<Ipv4, Ipv4Range> {
@@ -185,8 +185,8 @@ public class Ipv4RangeTest extends AbstractRangeTest<Ipv4, Ipv4Range> {
 
     @Test
     public void testSize() {
-        assertEquals(new Long(1), ip1.asRange().size());
-        assertEquals(new Long(MAXIMUM_VALUE + 1), Ipv4Range.from(FIRST_IPV4_ADDRESS).to(LAST_IPV4_ADDRESS).size());
+        assertEquals(Long.valueOf(1), ip1.asRange().size());
+        assertEquals(Long.valueOf(MAXIMUM_VALUE + 1), Ipv4Range.from(FIRST_IPV4_ADDRESS).to(LAST_IPV4_ADDRESS).size());
     }
 
     @Override

--- a/commons-ip-math/src/test/java/com/github/jgonian/ipmath/Ipv4Test.java
+++ b/commons-ip-math/src/test/java/com/github/jgonian/ipmath/Ipv4Test.java
@@ -23,21 +23,19 @@
  */
 package com.github.jgonian.ipmath;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+
 import java.math.BigInteger;
+
+import org.junit.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class Ipv4Test {
-
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void testEqualsContract() {
@@ -54,23 +52,23 @@ public class Ipv4Test {
 
     @Test
     public void testBuilderWithNull() {
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("from cannot be null");
-        Ipv4.of((BigInteger) null);
+    	assertThrows("from cannot be null", IllegalArgumentException.class, () -> {
+            Ipv4.of((BigInteger) null);
+    	});
     }
 
     @Test
     public void testUpperBound() {
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("Value of IPv4 has to be less than or equal to 4294967295");
-        new Ipv4(Ipv4.MAXIMUM_VALUE + 1);
+    	assertThrows("Value of IPv4 has to be less than or equal to 4294967295", IllegalArgumentException.class, () -> {
+            new Ipv4(Ipv4.MAXIMUM_VALUE + 1);
+    	});
     }
 
     @Test
     public void testLowerBound() {
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("Value of IPv4 has to be greater than or equal to 0");
-        new Ipv4(Ipv4.MINIMUM_VALUE - 1);
+        assertThrows("Value of IPv4 has to be greater than or equal to 0", IllegalArgumentException.class, () -> {
+            new Ipv4(Ipv4.MINIMUM_VALUE - 1);
+        });
     }
 
     @Test
@@ -100,58 +98,58 @@ public class Ipv4Test {
 
     @Test
     public void shouldFailOnLessOctets() {
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("Invalid IPv4 address: '10.1.1'");
-        Ipv4.parse("10.1.1");
+        assertThrows("Invalid IPv4 address: '10.1.1'", IllegalArgumentException.class, () -> {
+            Ipv4.parse("10.1.1");
+        });
     }
 
     @Test
     public void shouldFailOnMoreOctets() {
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("Invalid IPv4 address: '10.1.1.1.1'");
-        Ipv4.parse("10.1.1.1.1");
+        assertThrows("Invalid IPv4 address: '10.1.1.1.1'", IllegalArgumentException.class, () -> {
+            Ipv4.parse("10.1.1.1.1");
+        });
     }
 
     @Test
     public void shouldFailWhenEndingWithNonDigit() {
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("Invalid IPv4 address: '10.1.1.1.'");
-        Ipv4.parse("10.1.1.1.");
+        assertThrows("Invalid IPv4 address: '10.1.1.1.'", IllegalArgumentException.class, () -> {
+            Ipv4.parse("10.1.1.1.");
+        });
     }
 
     @Test
     public void shouldFailWhenStartingWithNonDigit() {
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("Invalid IPv4 address: '.10.1.1.1'");
-        Ipv4.parse(".10.1.1.1");
+        assertThrows("Invalid IPv4 address: '.10.1.1.1'", IllegalArgumentException.class, () -> {
+            Ipv4.parse(".10.1.1.1");
+        });
     }
 
     @Test
     public void shouldFailWhenOctetContainsNonDigit() {
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("Invalid IPv4 address: '10.a.1.0'");
-        Ipv4.parse("10.a.1.0");
+        assertThrows("Invalid IPv4 address: '10.a.1.0'", IllegalArgumentException.class, () -> {
+            Ipv4.parse("10.a.1.0");
+        });
     }
 
     @Test
     public void shouldFailOnOutOfBoundsByte() {
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("Invalid IPv4 address: '256.0.0.0'");
-        Ipv4.parse("256.0.0.0");
+        assertThrows("Invalid IPv4 address: '256.0.0.0'", IllegalArgumentException.class, () -> {
+            Ipv4.parse("256.0.0.0");
+        });
     }
 
     @Test
     public void shouldFailOnOutOfBoundsByte_NegativeByte() {
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("Invalid IPv4 address: '13.-40.0.0'");
-        Ipv4.parse("13.-40.0.0");
+        assertThrows("Invalid IPv4 address: '13.-40.0.0'", IllegalArgumentException.class, () -> {
+            Ipv4.parse("13.-40.0.0");
+        });
     }
 
     @Test
     public void shouldFailOnLeadingZeros() {
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("Invalid IPv4 address: '192.168.08.1'");
-        Ipv4.parse("192.168.08.1");
+        assertThrows("Invalid IPv4 address: '192.168.08.1'", IllegalArgumentException.class, () -> {
+            Ipv4.parse("192.168.08.1");
+        });
     }
 
     @Test
@@ -174,16 +172,16 @@ public class Ipv4Test {
 
     @Test
     public void shouldFailToCalculateLowerBoundWhenPrefixIsOutOfRange() {
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("Value [33] out of range: [0..32]");
-        Ipv4.parse("192.168.0.100").lowerBoundForPrefix(33);
+        assertThrows("Value [33] out of range: [0..32]", IllegalArgumentException.class, () -> {
+            Ipv4.parse("192.168.0.100").lowerBoundForPrefix(33);
+        });
     }
 
     @Test
     public void shouldFailToCalculateUpperBoundWhenPrefixIsOutOfRange() {
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("Value [33] out of range: [0..32]");
-        Ipv4.parse("192.168.0.100").upperBoundForPrefix(33);
+        assertThrows("Value [33] out of range: [0..32]", IllegalArgumentException.class, () -> {
+            Ipv4.parse("192.168.0.100").upperBoundForPrefix(33);
+        });
     }
 
     @Test

--- a/commons-ip-math/src/test/java/com/github/jgonian/ipmath/Ipv6DoubleColonTest.java
+++ b/commons-ip-math/src/test/java/com/github/jgonian/ipmath/Ipv6DoubleColonTest.java
@@ -23,31 +23,28 @@
  */
 package com.github.jgonian.ipmath;
 
-import org.junit.Rule;
+import static org.junit.Assert.assertThrows;
+
+import java.util.Arrays;
+import java.util.List;
+
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
-import java.util.Arrays;
-import java.util.List;
-
 @RunWith(Parameterized.class)
 public class Ipv6DoubleColonTest {
-
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
 
     @Parameter(0)
     public String input;
 
     @Test
     public void test() {
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("Invalid IPv6 address: '" + input + "'");
-        Ipv6.parse(input);
+        assertThrows("Invalid IPv6 address: '" + input + "'", IllegalArgumentException.class, () -> {
+            Ipv6.parse(input);
+        });
     }
 
     // Invalid IPv6 examples are taken from http://download.dartware.com/thirdparty/test-ipv6-regex.pl

--- a/commons-ip-math/src/test/java/com/github/jgonian/ipmath/Ipv6ParseInvalidTest.java
+++ b/commons-ip-math/src/test/java/com/github/jgonian/ipmath/Ipv6ParseInvalidTest.java
@@ -23,31 +23,28 @@
  */
 package com.github.jgonian.ipmath;
 
-import org.junit.Rule;
+import static org.junit.Assert.assertThrows;
+
+import java.util.Arrays;
+import java.util.List;
+
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
-import java.util.Arrays;
-import java.util.List;
-
 @RunWith(Parameterized.class)
 public class Ipv6ParseInvalidTest {
-
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
 
     @Parameter(0)
     public String input;
 
     @Test
     public void test() {
-        thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage("Invalid IPv6 address: '" + input + "'");
-        Ipv6.parse(input);
+        assertThrows("Invalid IPv6 address: '" + input + "'", IllegalArgumentException.class, () -> {
+            Ipv6.parse(input);
+        });
     }
 
     // Invalid IPv6 examples are copied from http://download.dartware.com/thirdparty/test-ipv6-regex.pl

--- a/commons-ip-math/src/test/java/com/github/jgonian/ipmath/Ipv6ParseValidTest.java
+++ b/commons-ip-math/src/test/java/com/github/jgonian/ipmath/Ipv6ParseValidTest.java
@@ -23,22 +23,17 @@
  */
 package com.github.jgonian.ipmath;
 
-import org.junit.Rule;
+import java.util.Arrays;
+import java.util.List;
+
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
-import java.util.Arrays;
-import java.util.List;
-
 @RunWith(Parameterized.class)
 public class Ipv6ParseValidTest {
-
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
 
     @Parameter(0)
     public String input;

--- a/commons-ip-math/src/test/java/com/github/jgonian/ipmath/Ipv6Test.java
+++ b/commons-ip-math/src/test/java/com/github/jgonian/ipmath/Ipv6Test.java
@@ -30,7 +30,7 @@ import org.junit.Test;
 import java.math.BigInteger;
 import java.util.ArrayList;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.*;
 
 public class Ipv6Test {

--- a/commons-ip-math/src/test/java/com/github/jgonian/ipmath/SizeComparatorReverseTest.java
+++ b/commons-ip-math/src/test/java/com/github/jgonian/ipmath/SizeComparatorReverseTest.java
@@ -23,7 +23,8 @@
  */
 package com.github.jgonian.ipmath;
 
-import static junit.framework.Assert.*;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 import java.util.Comparator;
 
 import org.junit.Test;

--- a/commons-ip-math/src/test/java/com/github/jgonian/ipmath/SizeComparatorTest.java
+++ b/commons-ip-math/src/test/java/com/github/jgonian/ipmath/SizeComparatorTest.java
@@ -23,7 +23,8 @@
  */
 package com.github.jgonian.ipmath;
 
-import static junit.framework.Assert.*;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 import java.util.Comparator;
 
 import org.junit.Test;

--- a/commons-ip-math/src/test/java/com/github/jgonian/ipmath/SortedRangeSetTest.java
+++ b/commons-ip-math/src/test/java/com/github/jgonian/ipmath/SortedRangeSetTest.java
@@ -23,7 +23,9 @@
  */
 package com.github.jgonian.ipmath;
 
-import static junit.framework.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;

--- a/commons-ip-math/src/test/java/com/github/jgonian/ipmath/SortedResourceSetTest.java
+++ b/commons-ip-math/src/test/java/com/github/jgonian/ipmath/SortedResourceSetTest.java
@@ -23,7 +23,9 @@
  */
 package com.github.jgonian.ipmath;
 
-import static junit.framework.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 import java.util.HashSet;
 import java.util.Set;
 

--- a/commons-ip-math/src/test/java/com/github/jgonian/ipmath/StartAndSizeComparatorReverseTest.java
+++ b/commons-ip-math/src/test/java/com/github/jgonian/ipmath/StartAndSizeComparatorReverseTest.java
@@ -23,7 +23,8 @@
  */
 package com.github.jgonian.ipmath;
 
-import static junit.framework.Assert.*;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertSame;
 import java.util.Comparator;
 
 import org.junit.Test;

--- a/commons-ip-math/src/test/java/com/github/jgonian/ipmath/StartAndSizeComparatorTest.java
+++ b/commons-ip-math/src/test/java/com/github/jgonian/ipmath/StartAndSizeComparatorTest.java
@@ -23,7 +23,8 @@
  */
 package com.github.jgonian.ipmath;
 
-import static junit.framework.Assert.*;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertSame;
 import java.util.Comparator;
 
 import org.junit.Test;

--- a/pom.xml
+++ b/pom.xml
@@ -3,14 +3,14 @@
 
     <groupId>com.github.jgonian</groupId>
     <artifactId>commons-ip-math-parent</artifactId>
-    <version>1.33-SNAPSHOT</version>
+    <version>2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>A project to make it easier to work with Internet resources, such as IPv4, IPv6 and AS numbers.</description>
     <url>http://github.com/jgonian/commons-ip-math</url>
 
     <properties>
-        <target.jdk>1.6</target.jdk>
+        <target.jdk>1.8</target.jdk>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -52,7 +52,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.3</version>
+                <version>3.8.1</version>
                 <configuration>
                     <source>${target.jdk}</source>
                     <target>${target.jdk}</target>


### PR DESCRIPTION
This came about due to a need for a fully JPMS compliant library, i.e. the addition of a `module-info.java`. This is supported by Java 9 and later, but to be able to make a jar compatible with earlier versions we need to use an MRJAR (multi-release). This is supported in Java 8 and onwards, so that must become the lowest common denominator.

For this reason, I have made this a major version bump. The change also necessitated updating some Maven plugins and dependencies including JUnit. As a result of updating JUnit, many deprecations needed to be fixed. The source is now warning free (with the need for a few suppression annotations).

To recap,

 * Minimum Java version increased to Java 8.
 * A Multi-release Jar is built with JPMS support. The module name is the same as the package, `com.github.jgonian.ipmath`.
 * Various Maven plugins updated.
 * Testing dependencies updated.
 * Resulting deprecations fixed.