### PR TITLE
Add support for java.net.InetAddress and byte arrays

### DIFF
--- a/commons-ip-math/src/main/java/com/github/jgonian/ipmath/Ipv4.java
+++ b/commons-ip-math/src/main/java/com/github/jgonian/ipmath/Ipv4.java
@@ -79,7 +79,7 @@ public final class Ipv4 extends AbstractIp<Ipv4, Ipv4Range> {
         Validate.isTrue(octets.length == TOTAL_OCTETS, "exactly " + TOTAL_OCTETS + " octets are required");
         long result = 0;
         for (int i = 0; i < octets.length; i++) {
-            result = addOctet(result, octets[i]);
+            result = addOctet(result, Byte.toUnsignedInt(octets[i]));
         }
         return new Ipv4(result);
     }

--- a/commons-ip-math/src/main/java/com/github/jgonian/ipmath/Ipv4.java
+++ b/commons-ip-math/src/main/java/com/github/jgonian/ipmath/Ipv4.java
@@ -24,6 +24,7 @@
 package com.github.jgonian.ipmath;
 
 import java.math.BigInteger;
+import java.net.Inet4Address;
 import java.util.regex.Pattern;
 
 public final class Ipv4 extends AbstractIp<Ipv4, Ipv4Range> {
@@ -72,6 +73,20 @@ public final class Ipv4 extends AbstractIp<Ipv4, Ipv4Range> {
 
     public static Ipv4 of(String value) {
         return parse(value);
+    }
+
+    public static Ipv4 of(byte[] octets) {
+        Validate.isTrue(octets.length == TOTAL_OCTETS, "exactly " + TOTAL_OCTETS + " octets are required");
+        long result = 0;
+        for (int i = 0; i < octets.length; i++) {
+            result = addOctet(result, octets[i]);
+        }
+        return new Ipv4(result);
+    }
+
+    public static Ipv4 of(Inet4Address value) {
+        Validate.notNull(value, "value is required");
+        return of(value.getAddress());
     }
 
     public static Ipv4 parse(String ipv4Address) {

--- a/commons-ip-math/src/main/java/com/github/jgonian/ipmath/Ipv4Range.java
+++ b/commons-ip-math/src/main/java/com/github/jgonian/ipmath/Ipv4Range.java
@@ -24,6 +24,7 @@
 package com.github.jgonian.ipmath;
 
 import java.math.BigInteger;
+import java.net.Inet4Address;
 
 public final class Ipv4Range extends AbstractIpRange<Ipv4, Ipv4Range> {
 
@@ -52,6 +53,14 @@ public final class Ipv4Range extends AbstractIpRange<Ipv4, Ipv4Range> {
     }
 
     public static Ipv4RangeBuilder from(Long from) {
+        return new Ipv4RangeBuilder(Ipv4.of(from));
+    }
+
+    public static Ipv4RangeBuilder from(byte[] from) {
+        return new Ipv4RangeBuilder(Ipv4.of(from));
+    }
+
+    public static Ipv4RangeBuilder from(Inet4Address from) {
         return new Ipv4RangeBuilder(Ipv4.of(from));
     }
 
@@ -122,6 +131,14 @@ public final class Ipv4Range extends AbstractIpRange<Ipv4, Ipv4Range> {
         }
 
         public Ipv4Range to(Long end) {
+            return to(Ipv4.of(end));
+        }
+
+        public Ipv4Range to(byte[] end) {
+            return to(Ipv4.of(end));
+        }
+
+        public Ipv4Range to(Inet4Address end) {
             return to(Ipv4.of(end));
         }
 

--- a/commons-ip-math/src/main/java/com/github/jgonian/ipmath/Ipv6.java
+++ b/commons-ip-math/src/main/java/com/github/jgonian/ipmath/Ipv6.java
@@ -78,7 +78,7 @@ public final class Ipv6 extends AbstractIp<Ipv6, Ipv6Range> {
         Validate.isTrue(octets.length == TOTAL_OCTETS, "exactly " + TOTAL_OCTETS + " octets are required");
         BigInteger result = BigInteger.ZERO;
         for (int i = 0; i < octets.length; i++) {
-            result = result.shiftLeft(BITS_PER_OCTET).add(BigInteger.valueOf(octets[i]));
+            result = result.shiftLeft(BITS_PER_OCTET).add(BigInteger.valueOf(Byte.toUnsignedInt(octets[i])));
         }
         return new Ipv6(result);
     }

--- a/commons-ip-math/src/main/java/com/github/jgonian/ipmath/Ipv6.java
+++ b/commons-ip-math/src/main/java/com/github/jgonian/ipmath/Ipv6.java
@@ -24,6 +24,7 @@
 package com.github.jgonian.ipmath;
 
 import java.math.BigInteger;
+import java.net.Inet6Address;
 import java.util.regex.Pattern;
 
 import static java.math.BigInteger.ONE;
@@ -47,8 +48,10 @@ public final class Ipv6 extends AbstractIp<Ipv6, Ipv6Range> {
     private static final String COLON = ":";
     private static final String ZERO = "0";
     private static final int BITS_PER_PART = 16;
-    private static final int TOTAL_OCTETS = 8;
+    private static final int TOTAL_PARTS = 8;
     private static final int COLON_COUNT_IPV6 = 7;
+    private static final int BITS_PER_OCTET = 8;
+    private static final int TOTAL_OCTETS = 16;
     private static final BigInteger MINUS_ONE = BigInteger.valueOf(-1);
 
     private final BigInteger value;
@@ -69,6 +72,20 @@ public final class Ipv6 extends AbstractIp<Ipv6, Ipv6Range> {
 
     public static Ipv6 of(String value) {
         return parse(value);
+    }
+
+    public static Ipv6 of(byte[] octets) {
+        Validate.isTrue(octets.length == TOTAL_OCTETS, "exactly " + TOTAL_OCTETS + " octets are required");
+        BigInteger result = BigInteger.ZERO;
+        for (int i = 0; i < octets.length; i++) {
+            result = result.shiftLeft(BITS_PER_OCTET).add(BigInteger.valueOf(octets[i]));
+        }
+        return new Ipv6(result);
+    }
+
+    public static Ipv6 of(Inet6Address value) {
+        Validate.notNull(value, "value is required");
+        return of(value.getAddress());
     }
 
     @Override
@@ -174,8 +191,8 @@ public final class Ipv6 extends AbstractIp<Ipv6, Ipv6Range> {
                 ipv6String = expandMissingColons(ipv6String, indexOfDoubleColons);
             }
 
-            final String[] split = ipv6String.split(COLON, TOTAL_OCTETS);
-            Validate.isTrue(split.length == TOTAL_OCTETS);
+            final String[] split = ipv6String.split(COLON, TOTAL_PARTS);
+            Validate.isTrue(split.length == TOTAL_PARTS);
             BigInteger ipv6value = BigInteger.ZERO;
             for (String part : split) {
                 Validate.isTrue(part.length() <= MAX_PART_LENGTH);

--- a/commons-ip-math/src/main/java/com/github/jgonian/ipmath/Ipv6Range.java
+++ b/commons-ip-math/src/main/java/com/github/jgonian/ipmath/Ipv6Range.java
@@ -25,6 +25,7 @@ package com.github.jgonian.ipmath;
 
 import static java.math.BigInteger.*;
 import java.math.BigInteger;
+import java.net.Inet6Address;
 
 public final class Ipv6Range extends AbstractIpRange<Ipv6, Ipv6Range> {
 
@@ -49,6 +50,14 @@ public final class Ipv6Range extends AbstractIpRange<Ipv6, Ipv6Range> {
     }
 
     public static Ipv6RangeBuilder from(BigInteger from) {
+        return new Ipv6RangeBuilder(Ipv6.of(from));
+    }
+
+    public static Ipv6RangeBuilder from(byte[] from) {
+        return new Ipv6RangeBuilder(Ipv6.of(from));
+    }
+
+    public static Ipv6RangeBuilder from(Inet6Address from) {
         return new Ipv6RangeBuilder(Ipv6.of(from));
     }
 
@@ -116,6 +125,14 @@ public final class Ipv6Range extends AbstractIpRange<Ipv6, Ipv6Range> {
         }
         
         public Ipv6Range to(BigInteger end) {
+            return to(Ipv6.of(end));
+        }
+
+        public Ipv6Range to(byte[] end) {
+            return to(Ipv6.of(end));
+        }
+
+        public Ipv6Range to(Inet6Address end) {
             return to(Ipv6.of(end));
         }
 

--- a/commons-ip-math/src/test/java/com/github/jgonian/ipmath/Ipv4RangeTest.java
+++ b/commons-ip-math/src/test/java/com/github/jgonian/ipmath/Ipv4RangeTest.java
@@ -25,6 +25,9 @@ package com.github.jgonian.ipmath;
 
 import org.junit.Test;
 
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -222,6 +225,21 @@ public class Ipv4RangeTest extends AbstractRangeTest<Ipv4, Ipv4Range> {
     @Test
     public void testBuilderWithLongs() {
         Ipv4Range range = Ipv4Range.from(1l).to(3l);
+        assertEquals(ip1, range.start());
+        assertEquals(ip3, range.end());
+    }
+
+    @Test
+    public void testBuilderWithByteArrays() {
+        Ipv4Range range = Ipv4Range.from(new byte[] {0, 0, 0, 1}).to(new byte[] {0, 0, 0, 3});
+        assertEquals(ip1, range.start());
+        assertEquals(ip3, range.end());
+    }
+
+    @Test
+    public void testBuilderWithInetAddresses() throws UnknownHostException
+    {
+        Ipv4Range range = Ipv4Range.from((Inet4Address) InetAddress.getByAddress(new byte[]{0, 0, 0, 1})).to((Inet4Address) InetAddress.getByAddress(new byte[]{0, 0, 0, 3}));
         assertEquals(ip1, range.start());
         assertEquals(ip3, range.end());
     }

--- a/commons-ip-math/src/test/java/com/github/jgonian/ipmath/Ipv4Test.java
+++ b/commons-ip-math/src/test/java/com/github/jgonian/ipmath/Ipv4Test.java
@@ -59,6 +59,13 @@ public class Ipv4Test {
     }
 
     @Test
+    public void testByteArrayBuilder() throws UnknownHostException {
+        Ipv4 sample = new Ipv4(3325256709l);
+        // Explicitly test for cases that involve Java's unsigned byte usage.
+        assertEquals(sample, Ipv4.of(InetAddress.getByName("198.51.100.5").getAddress()));
+    }
+
+    @Test
     public void testBuilderWithNull() {
         thrown.expect(IllegalArgumentException.class);
         thrown.expectMessage("from cannot be null");

--- a/commons-ip-math/src/test/java/com/github/jgonian/ipmath/Ipv4Test.java
+++ b/commons-ip-math/src/test/java/com/github/jgonian/ipmath/Ipv4Test.java
@@ -27,6 +27,9 @@ import static junit.framework.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import java.math.BigInteger;
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
@@ -45,11 +48,14 @@ public class Ipv4Test {
     }
 
     @Test
-    public void testBuilderMethods() {
+    public void testBuilderMethods() throws UnknownHostException {
         Ipv4 sample = new Ipv4(1l);
         assertEquals(sample, Ipv4.of(BigInteger.ONE));
         assertEquals(sample, Ipv4.of(1l));
         assertEquals(sample, Ipv4.of("0.0.0.1"));
+        assertEquals(sample, Ipv4.of(new byte[] {0, 0, 0, 1}));
+        assertEquals(sample, Ipv4.of((Inet4Address) InetAddress.getByAddress(new byte[] {0, 0, 0, 1})));
+        assertEquals(InetAddress.getByAddress(new byte[] {0, 0, 0, 1}), InetAddress.getByName("0.0.0.1"));
     }
 
     @Test
@@ -57,6 +63,27 @@ public class Ipv4Test {
         thrown.expect(IllegalArgumentException.class);
         thrown.expectMessage("from cannot be null");
         Ipv4.of((BigInteger) null);
+    }
+
+    @Test
+    public void testBuilderWithNullInetAddress() {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("value is required");
+        Ipv4.of((Inet4Address) null);
+    }
+
+    @Test
+    public void testBuilderNotEnoughBytes() {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("exactly 4 octets are required");
+        Ipv4.of(new byte[3]);
+    }
+
+    @Test
+    public void testBuilderToManyBytes() {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("exactly 4 octets are required");
+        Ipv4.of(new byte[5]);
     }
 
     @Test

--- a/commons-ip-math/src/test/java/com/github/jgonian/ipmath/Ipv6RangeTest.java
+++ b/commons-ip-math/src/test/java/com/github/jgonian/ipmath/Ipv6RangeTest.java
@@ -26,6 +26,9 @@ package com.github.jgonian.ipmath;
 import org.junit.Test;
 
 import java.math.BigInteger;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.*;
 
 import static com.github.jgonian.ipmath.Ipv4.LAST_IPV4_ADDRESS;
@@ -209,6 +212,20 @@ public class Ipv6RangeTest extends AbstractRangeTest<Ipv6, Ipv6Range> {
     @Test
     public void testBuilderWithBigIntegers() {
         Ipv6Range range = Ipv6Range.from(BigInteger.valueOf(1l)).to(BigInteger.valueOf(3l));
+        assertEquals(ip1, range.start());
+        assertEquals(ip3, range.end());
+    }
+
+    @Test
+    public void testBuilderWithByteArrays() {
+        Ipv6Range range = Ipv6Range.from(new byte[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}).to(new byte[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3});
+        assertEquals(ip1, range.start());
+        assertEquals(ip3, range.end());
+    }
+
+    @Test
+    public void testBuilderWithInetAddresses() throws UnknownHostException {
+        Ipv6Range range = Ipv6Range.from((Inet6Address) InetAddress.getByAddress(new byte[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1})).to((Inet6Address) InetAddress.getByAddress(new byte[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3}));
         assertEquals(ip1, range.start());
         assertEquals(ip3, range.end());
     }

--- a/commons-ip-math/src/test/java/com/github/jgonian/ipmath/Ipv6Test.java
+++ b/commons-ip-math/src/test/java/com/github/jgonian/ipmath/Ipv6Test.java
@@ -28,6 +28,7 @@ import nl.jqno.equalsverifier.Warning;
 import org.junit.Test;
 
 import java.math.BigInteger;
+import java.net.Inet6Address;
 import java.util.ArrayList;
 
 import static junit.framework.Assert.assertEquals;
@@ -48,6 +49,11 @@ public class Ipv6Test {
     @Test
     public void testFactoryMethodWithString() {
         assertEquals(new Ipv6(BigInteger.ZERO), Ipv6.of("::"));
+    }
+
+    @Test
+    public void testFactoryMethodWithByteArray() {
+        assertEquals(new Ipv6(BigInteger.ZERO), Ipv6.of(new byte[16])); // Java initializes byte array to all zero.
     }
 
     // Representing IPv6 Addresses
@@ -183,8 +189,23 @@ public class Ipv6Test {
     }
 
     @Test(expected = IllegalArgumentException.class)
+    public void shouldNotParseNullInetAddress() {
+        Ipv6.of((Inet6Address) null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
     public void shouldFailOnEmptyString() {
         Ipv6.parse("");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testBuilderNotEnoughBytes() {
+        Ipv4.of(new byte[15]);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testBuilderToManyBytes() {
+        Ipv4.of(new byte[17]);
     }
 
     @Test

--- a/commons-ip-math/src/test/java/com/github/jgonian/ipmath/Ipv6Test.java
+++ b/commons-ip-math/src/test/java/com/github/jgonian/ipmath/Ipv6Test.java
@@ -29,6 +29,8 @@ import org.junit.Test;
 
 import java.math.BigInteger;
 import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.ArrayList;
 
 import static junit.framework.Assert.assertEquals;
@@ -54,6 +56,12 @@ public class Ipv6Test {
     @Test
     public void testFactoryMethodWithByteArray() {
         assertEquals(new Ipv6(BigInteger.ZERO), Ipv6.of(new byte[16])); // Java initializes byte array to all zero.
+    }
+
+    @Test
+    public void testByteArrayBuilder() throws UnknownHostException {
+        // Explicitly test for cases that involve Java's unsigned byte usage.
+        assertEquals(Ipv6.LAST_IPV6_ADDRESS, Ipv6.of(InetAddress.getByName("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff").getAddress()));
     }
 
     // Representing IPv6 Addresses


### PR DESCRIPTION
Additional constructor and builder overloads are added to allow the API to accept instances of `Inet4Address` and `Inet6Address`, as well as byte arrays that represent IP addresses.

Fixes #31