### PR TITLE
CI should run on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,6 @@
 name: CI Build
 
-on:
-  push:
-    branches:
-      - '**'
-    paths-ignore:
-      - README.md
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
When pull requests are made from branches that aren't part of this repository, the continuous integration flow should still run.

This change sacrifices the exception made for the readme file.